### PR TITLE
Add VSCode Folder to Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 # IDE
 .idea/
+.vscode/


### PR DESCRIPTION
I use VSCode and the `.vscode/` folder is an IDE folder. It doesn't need to be tracked.