### PR TITLE
Prism checkpoint URL updated.

### DIFF
--- a/tests/test_data/expected_outputs/metrics/test_prism.json
+++ b/tests/test_data/expected_outputs/metrics/test_prism.json
@@ -12,7 +12,7 @@
         "log_base": 2,
         "temperature": 1.0
       },
-      "model_path_or_url": "http://data.statmt.org/prism/m39v1.tar",
+      "model_path_or_url": "default",
       "lang": "en",
       "segment_scores": false,
       "normalized": false
@@ -34,7 +34,7 @@
         "log_base": 2,
         "temperature": 1.0
       },
-      "model_path_or_url": "http://data.statmt.org/prism/m39v1.tar",
+      "model_path_or_url": "default",
       "lang": "en",
       "segment_scores": true,
       "normalized": true
@@ -53,7 +53,7 @@
         "log_base": 2,
         "temperature": 1.0
       },
-      "model_path_or_url": "http://data.statmt.org/prism/m39v1.tar",
+      "model_path_or_url": "default",
       "lang": "en",
       "segment_scores": false,
       "normalized": false
@@ -75,7 +75,7 @@
         "log_base": 2,
         "temperature": 1.0
       },
-      "model_path_or_url": "http://data.statmt.org/prism/m39v1.tar",
+      "model_path_or_url": "default",
       "lang": "en",
       "segment_scores": true,
       "normalized": true
@@ -94,7 +94,7 @@
         "log_base": 2,
         "temperature": 1.0
       },
-      "model_path_or_url": "http://data.statmt.org/prism/m39v1.tar",
+      "model_path_or_url": "default",
       "lang": "en",
       "segment_scores": false,
       "normalized": false
@@ -116,7 +116,7 @@
         "log_base": 2,
         "temperature": 1.0
       },
-      "model_path_or_url": "http://data.statmt.org/prism/m39v1.tar",
+      "model_path_or_url": "default",
       "lang": "en",
       "segment_scores": true,
       "normalized": true


### PR DESCRIPTION
Closes #91.

The default Prism model is uploaded to HF Model hub, the checkpoint URL changed accordingly.