### PR TITLE
Fixed warning message in BLEURT default initialization

### DIFF
--- a/jury/metrics/bleurt/bleurt_for_language_generation.py
+++ b/jury/metrics/bleurt/bleurt_for_language_generation.py
@@ -134,7 +134,7 @@ class BleurtForLanguageGeneration(MetricForLanguageGeneration):
             logger.warning(
                 "Using default BLEURT-Base checkpoint for sequence maximum length 128. "
                 "You can use a bigger model for better results with e.g: "
-                "Jury(metric={path: 'bleurt', 'checkpoint': 'bleurt-large-512'})."
+                "Jury(metrics=[{'path': 'bleurt', 'config_name': 'bleurt-large-512'}])."
             )
             self.config_name = "bleurt-base-128"
 


### PR DESCRIPTION
Jury constructor accepts `metrics` as a string, an object from Metric class or list of metric configurations inside a dict. In addition, BLEURT metric checks for `config_name`key instead of `checkpoint` key. Thus, this warning message misleads if default model is not used.

Here is an example of incorrect initialization and warning message: 

<img width="837" alt="Screen Shot 2022-05-16 at 15 43 06" src="https://user-images.githubusercontent.com/7279205/168595030-eba7908c-c8cc-4f26-88a9-3023d9dab8ea.png">

`checkpoint` is ignored:
<img width="1091" alt="Screen Shot 2022-05-16 at 15 42 55" src="https://user-images.githubusercontent.com/7279205/168595056-95371423-25c5-4f0f-bf43-f88fe66aa8e0.png">


