### PR TITLE
`ZeroDivisionError` on precision and recall values.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,11 +58,11 @@ jobs:
 
       - name: Lint with flake8 and black
         run: |
-          python tests/run_code_style.py check
+          python -m tests.run_code_style check
 
       - name: Run tests.
         run: |
-          python tests/run_tests.py
+          python -m tests.run_tests
 
       - name: Test CLI for installed package
         run: |

--- a/jury/metrics/precision/precision_for_language_generation.py
+++ b/jury/metrics/precision/precision_for_language_generation.py
@@ -87,13 +87,11 @@ class PrecisionForLanguageGeneration(MetricForLanguageGeneration):
         scores = []
         predictions, references = self._tokenize(predictions, references)
         for pred, ref in zip(predictions, references):
-            score = 0
-            pred_counts = Counter(pred)
-            ref_counts = Counter(ref)
-            for token, pred_count in pred_counts.items():
-                if token in ref_counts:
-                    score += min(pred_count, ref_counts[token])  # Intersection count
-            scores.append(score / len(pred))
+            if len(pred) == 0:
+                scores.append(0)
+                continue
+            common = Counter(pred) & Counter(ref)  # Intersection count
+            scores.append(sum(common.values()) / len(pred))
         avg_score = sum(scores) / len(scores)
         return {"score": avg_score}
 

--- a/jury/metrics/recall/recall_for_language_generation.py
+++ b/jury/metrics/recall/recall_for_language_generation.py
@@ -91,13 +91,11 @@ class RecallForLanguageGeneration(MetricForLanguageGeneration):
         scores = []
         predictions, references = self._tokenize(predictions, references)
         for pred, ref in zip(predictions, references):
-            score = 0
-            pred_counts = Counter(pred)
-            ref_counts = Counter(ref)
-            for token, pred_count in pred_counts.items():
-                if token in ref_counts:
-                    score += min(pred_count, ref_counts[token])  # Intersection count
-            scores.append(score / len(ref))
+            if len(ref) == 0:
+                scores.append(0)
+                continue
+            common = Counter(pred) & Counter(ref)  # Intersection count
+            scores.append(sum(common.values()) / len(ref))
         avg_score = sum(scores) / len(scores)
         return {"score": avg_score}
 


### PR DESCRIPTION
If there's no tokens for normalized text of pred or ref strings, mitigate zero division error.