### PR TITLE
Add try/catch block across ZeroDivisionError for AccuracyForLanguageGeneration._compute_single_pred_single_ref

### DIFF
--- a/jury/metrics/accuracy/accuracy_for_language_generation.py
+++ b/jury/metrics/accuracy/accuracy_for_language_generation.py
@@ -102,12 +102,8 @@ class AccuracyForLanguageGeneration(MetricForLanguageGeneration):
         scores = []
         predictions, references = self._tokenize(predictions, references)
         for pred, ref in zip(predictions, references):
-            score = 0
-            pred_counts = Counter(pred)
-            ref_counts = Counter(ref)
-            for token, pred_count in pred_counts.items():
-                if token in ref_counts:
-                    score += min(pred_count, ref_counts[token])  # Intersection count
+            common = Counter(pred) & Counter(ref)  # Intersection count
+            score = sum(common.values())
             try:
                 scores.append(score / max(len(pred), len(ref)))
             except ZeroDivisionError:

--- a/jury/metrics/accuracy/accuracy_for_language_generation.py
+++ b/jury/metrics/accuracy/accuracy_for_language_generation.py
@@ -111,7 +111,7 @@ class AccuracyForLanguageGeneration(MetricForLanguageGeneration):
             try:
                 scores.append(score / max(len(pred), len(ref)))
             except ZeroDivisionError:
-                logger.warning("Empty pred/ref. Ignoring!")
+                logger.warning("Empty pred & ref after preprocess (`normalize_text`) step. Ignoring!")
 
         avg_score = sum(scores) / len(scores)
         return {"score": avg_score}

--- a/jury/metrics/accuracy/accuracy_for_language_generation.py
+++ b/jury/metrics/accuracy/accuracy_for_language_generation.py
@@ -24,9 +24,13 @@ from typing import Callable
 import evaluate
 import numpy as np
 
+from evaluate.utils.logging import get_logger
+
 from jury.collator import Collator
 from jury.metrics._core import MetricForLanguageGeneration
 from jury.utils.nlp import normalize_text
+
+logger = get_logger(__name__)
 
 _CITATION = """\
 @article{scikit-learn,
@@ -66,7 +70,7 @@ Examples:
     >>> accuracy = jury.load_metric("accuracy")
     >>> predictions = [["the cat is on the mat", "There is cat playing on the mat"], ["Look! a wonderful day."]]
     >>> references = [
-        ["the cat is playing on the mat.", "The cat plays on the mat."], 
+        ["the cat is playing on the mat.", "The cat plays on the mat."],
         ["Today is a wonderful day", "The weather outside is wonderful."]
     ]
     >>> results = accuracy.compute(predictions=predictions, references=references)
@@ -104,7 +108,11 @@ class AccuracyForLanguageGeneration(MetricForLanguageGeneration):
             for token, pred_count in pred_counts.items():
                 if token in ref_counts:
                     score += min(pred_count, ref_counts[token])  # Intersection count
-            scores.append(score / max(len(pred), len(ref)))
+            try:
+                scores.append(score / max(len(pred), len(ref)))
+            except ZeroDivisionError:
+                logger.warning("Empty pred/ref. Ignoring!")
+
         avg_score = sum(scores) / len(scores)
         return {"score": avg_score}
 

--- a/jury/metrics/accuracy/accuracy_for_language_generation.py
+++ b/jury/metrics/accuracy/accuracy_for_language_generation.py
@@ -23,7 +23,6 @@ from typing import Callable
 
 import evaluate
 import numpy as np
-
 from evaluate.utils.logging import get_logger
 
 from jury.collator import Collator

--- a/jury/metrics/prism/prism_for_language_generation.py
+++ b/jury/metrics/prism/prism_for_language_generation.py
@@ -223,8 +223,8 @@ class PrismForLanguageGeneration(MetricForLanguageGeneration):
     @staticmethod
     def _normalize_score(score: Union[float, List[float]], exponent: float):
         if isinstance(score, float):
-            return exponent**score
-        return [exponent**s for s in score]
+            return exponent ** score
+        return [exponent ** s for s in score]
 
     def _compute_single_pred_single_ref(
         self,

--- a/jury/metrics/prism/prism_for_language_generation.py
+++ b/jury/metrics/prism/prism_for_language_generation.py
@@ -223,8 +223,8 @@ class PrismForLanguageGeneration(MetricForLanguageGeneration):
     @staticmethod
     def _normalize_score(score: Union[float, List[float]], exponent: float):
         if isinstance(score, float):
-            return exponent ** score
-        return [exponent ** s for s in score]
+            return exponent**score
+        return [exponent**s for s in score]
 
     def _compute_single_pred_single_ref(
         self,


### PR DESCRIPTION
This addresses the issue mentioned in issue #122 .

For now, I have handled the error under a try/catch block. Please let me know if this is enough to be merged. 